### PR TITLE
'openWritingPipe(int)' is ambiguous - Solution

### DIFF
--- a/RF24SN.cpp
+++ b/RF24SN.cpp
@@ -126,7 +126,7 @@ RF24SNPacket RF24SN::sendPacket(RF24SNPacket packet)
     
     //temporarily overwrite the pipe 0 with address 0
     //this is not intuitive, but otherwise this node would also listen to all packets sent to base
-    _radio->openWritingPipe(0);
+    _radio->openWritingPipe((uint64_t)0);
      
     //start listening for the ack packet from base
     //on pipe 0, there is 0. on pipe 1, there is unique address of this node


### PR DESCRIPTION
Solves "Arduino/libraries/RF24SN_Arduino_Client/RF24SN.cpp:129:30: error: call of overloaded 'openWritingPipe(int)' is ambiguous" by casting to (uint64_t)
